### PR TITLE
Improve base transformer with transforming dates in passed array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes History
 
+1.1.0
+------
+- Format passed into array dates in BaseTransformer. Previous version formats only dates in model
+- Resolve issue with `$hidden` and `$visible` arrays of fields in model. Previously only `$hidden` was taken into account
+
 1.0.17
 ------
 Require saritasa/php-common after extracting base Dto class

--- a/tests/BaseTransformerTest.php
+++ b/tests/BaseTransformerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Saritasa\Transformers\Tests;
+
+use Carbon\Carbon;
+use Saritasa\Transformers\BaseTransformer;
+use Saritasa\Transformers\DtoModel;
+
+class BaseTransformerTest extends TestCase
+{
+    function testModelTransform()
+    {
+        $createdAt = '2017-06-15 06:31:07';
+
+        $user = new User([
+            'first_name' => 'Ivan',
+            'last_name' => 'Ivanov',
+            'full_name' => 'Ivan Ivanov',
+            'birthday' => Carbon::parse('1985-06-15'),
+            'created_at' => Carbon::parse($createdAt),
+            'updated_at' => Carbon::parse('2017-06-15 06:31:07'),
+        ]);
+        $user->email = 'ivan@example.com';
+
+        $transformer = new BaseTransformer();
+        $result = $transformer->transform($user);
+
+        static::assertEquals(count($user->getVisible()), count($result));
+        static::assertArrayHasKey('full_name', $result);
+        static::assertArrayNotHasKey('email', $result);
+        static::assertEquals(Carbon::parse($createdAt)->format(Carbon::ISO8601), $result['created_at']);
+    }
+
+    function testArrayTransform()
+    {
+        $birthday = '2017-06-15';
+
+        $user = new class (['name' => 'Ivan', 'birthday' => Carbon::parse($birthday)]) extends DtoModel
+        {
+            protected $name;
+            protected $birthday;
+        };
+
+        $transformer = new BaseTransformer();
+        $result = $transformer->transform($user);
+
+        static::assertEquals(count($user->toArray()), count($result));
+        static::assertArrayHasKey('name', $result);
+        static::assertArrayHasKey('birthday', $result);
+        static::assertEquals(Carbon::parse($birthday)->format(Carbon::ISO8601), $result['birthday']);
+    }
+}

--- a/tests/ObjectFieldsTransformerTest.php
+++ b/tests/ObjectFieldsTransformerTest.php
@@ -18,10 +18,13 @@ class ObjectFieldsTransformerTest extends TestCase
             'device_type' => 'android'
         ]));
 
-        $transformer = new ObjectFieldsTransformer('first_name', 'device.device_type');
+        $user->setRelation('role', null);
+
+        $transformer = new ObjectFieldsTransformer('first_name', 'device.device_type', 'role.name');
         $result = $transformer->transform($user);
-        static::assertEquals(2, count(array_keys($result)));
+        static::assertEquals(3, count(array_keys($result)));
         static::assertEquals('Ivan', $result['first_name']);
         static::assertEquals('android', $result['device.device_type']);
+        static::assertEquals(null, $result['role.name']);
     }
 }


### PR DESCRIPTION
- Format passed into array dates in BaseTransformer. Previous version formats only dates in model
- Resolve issue with `$hidden` and `$visible` arrays of fields in model. Previously only `$hidden` was taken into account
